### PR TITLE
feat(authlib): add RP-initiated logout support with custom BaseApp

### DIFF
--- a/src/simplerr/authlib/apps.py
+++ b/src/simplerr/authlib/apps.py
@@ -1,8 +1,50 @@
+from authlib.common.security import generate_token
+from authlib.common.urls import add_params_to_uri
 from authlib.integrations.base_client import BaseApp, OAuth2Mixin, OpenIDMixin, OAuthError, OAuth1Mixin
 from authlib.integrations.requests_client import OAuth2Session, OAuth1Session
+from authlib.oauth2 import OAuth2Error
+
 from simplerr.dispatcher import Request
 from simplerr import web
 
+# TODO: remove when updated to authlib>=1.7.0
+class CustomBaseApp(BaseApp):
+    def create_logout_url(
+            self,
+            post_logout_redirect_uri=None,
+            id_token_hint=None,
+            state=None,
+            **kwargs
+    ):
+        """Generate the end session URL for RP-initiated Logout.
+
+        :param post_logout_redirect_uri: URI to redirect to after Logout.
+        :param id_token_hint: ID Token for previously issued to the RP
+        :param state: Opaque value for maintaining state
+        :param kwargs: Extra parameters (client_id, logout_hint, ui_locales)
+        :return: dict with 'url' and 'state' keys.
+        """
+        metadata = self.load_server_metadata()
+        end_session_endpoint = metadata.get('end_session_endpoint', None)
+
+        if not end_session_endpoint:
+            raise RuntimeError("Missing 'end_session_endpoint' in metadata.")
+
+        params = {}
+        if id_token_hint:
+            params['id_token_hint'] = id_token_hint
+        if post_logout_redirect_uri:
+            params['post_logout_redirect_uri'] = post_logout_redirect_uri
+            if state is None:
+                state = generate_token(20)
+            params['state'] = state
+
+        for key in ("client_id", "logout_hint", "ui_locales"):
+            if key in kwargs:
+                params[key] = kwargs.pop(key)
+
+        url = add_params_to_uri(end_session_endpoint, params)
+        return {'url': url, 'state': state}
 
 class SimplerrMixin:
 
@@ -25,7 +67,7 @@ class SimplerrMixin:
         self.save_authorize_data(request, redirect_uri=redirect_uri, **rv)
         return web.redirect(rv['url'])
 
-class SimplerrOAuth1App(SimplerrMixin, OAuth1Mixin, BaseApp):
+class SimplerrOAuth1App(SimplerrMixin, OAuth1Mixin, CustomBaseApp):
     client_cls = OAuth1Session
 
     def authorize_access_token(self, request: Request, **kwargs):
@@ -48,7 +90,7 @@ class SimplerrOAuth1App(SimplerrMixin, OAuth1Mixin, BaseApp):
         self.framework.clear_state_data(request.session, state)
         return self.fetch_access_token(**params)
 
-class SimplerrOAuth2App(SimplerrMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
+class SimplerrOAuth2App(SimplerrMixin, OAuth2Mixin, OpenIDMixin, CustomBaseApp):
     client_cls = OAuth2Session
 
     def authorize_access_token(self, request: Request, **kwargs):
@@ -60,7 +102,7 @@ class SimplerrOAuth2App(SimplerrMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
             error = request.args.get('error')
             if error:
                 description = request.args.get('error_description')
-                raise OAuthError(error=error, description=description)
+                raise OAuth2Error(error=error, description=description)
             params = {
                 "code": request.args.get('code'),
                 "state": request.args.get('state'),
@@ -89,3 +131,42 @@ class SimplerrOAuth2App(SimplerrMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
             token['userinfo'] = userinfo
 
         return token
+
+    def logout_redirect(
+            self, request, post_logout_redirect_uri=None, id_token_hint=None, **kwargs
+    ):
+        """Create a HTTP redirect for End Session Endpoint (RP-initiated Logout).
+
+        :param request: HTTP request instance from simplerr
+        :param post_logout_redirect_uri: URI to redirect to after logging out.
+        :param id_token_hint: ID Token previously issued to the RP
+        :param kwargs: Extra parameters (state, client_id, logout_hint, ui_locales).
+        :return: A HTTP redirect response.
+        """
+        result = self.create_logout_url(
+            post_logout_redirect_uri=post_logout_redirect_uri,
+            id_token_hint=id_token_hint,
+            **kwargs
+        )
+        if result.get('state', None):
+            self.framework.set_state_data(request.session, result['state'], {
+                'post_logout_redirect_uri': post_logout_redirect_uri,
+            })
+        return web.redirect(result['url'])
+
+    def validate_logout_response(self, request):
+        """Validate the state parameter from the logout callback
+
+        :param request: HTTP request instance from simplerr
+        :return: The state data dict
+        :raises OAuth2Error: if state is missing or invalid
+        """
+        state = request.args.get('state')
+        if not state:
+            raise OAuth2Error(description='Missing "state" parameter')
+        state_data = self.framework.get_state_data(request.session, state)
+        if not state_data:
+            raise OAuth2Error(description='Invalid "state" parameter')
+
+        self.framework.clear_state_data(request.session, state)
+        return state_data


### PR DESCRIPTION
- Introduced `CustomBaseApp` to extend logout functionality.
- Added `create_logout_url`, `logout_redirect`, and `validate_logout_response` methods.
- Updated `SimplerrOAuth1App` and `SimplerrOAuth2App` to inherit from `CustomBaseApp`.